### PR TITLE
Fixes a typo

### DIFF
--- a/Zephyr.swift
+++ b/Zephyr.swift
@@ -322,7 +322,7 @@ private extension Zephyr {
 
      Synchronizes specific keys to/from NSUbiquitousKeyValueStore and NSUserDefaults.
 
-     - parameter keys: Array of leys to synchronize.
+     - parameter keys: Array of keys to synchronize.
      - parameter dataStore: Signifies if keys should be synchronized to/from iCloud.
 
      */


### PR DESCRIPTION
Fixes a typo on the Swift 3 branch (haven't checked the master one)

We're playing around with your helper for https://pspdfkit.com/viewer to sync the document position - seems perfect! Thanks!
