### PR TITLE
Added Mac compatibility with an OS check

### DIFF
--- a/Zephyr/Zephyr.swift
+++ b/Zephyr/Zephyr.swift
@@ -62,9 +62,17 @@ public class Zephyr: NSObject {
         NotificationCenter.default.addObserver(self, selector: #selector(keysDidChangeOnCloud(notification:)),
                                                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
                                                object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
-                                               name: NSNotification.Name.UIApplicationWillEnterForeground,
-                                               object: nil)
+        
+        #if os(iOS)
+            NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
+                                                   name: NSNotification.Name.UIApplicationWillEnterForeground,
+                                                   object: nil)
+        #elseif os(macOS)
+            NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
+                                                   name: NSNotification.Name.NSApplicationWillBecomeActive,
+                                                   object: nil)
+        #endif
+        
         NSUbiquitousKeyValueStore.default().synchronize()
     }
 


### PR DESCRIPTION
Zephyr is really cool, and it would be awesome if it worked on macOS as well. I added a quick OS check to one line of code that wasn't compatible in order to use NSApplication instead of UIApplication if it is on macOS. Am I right to guess that the rest should already be compatible and working on macOS as well?