### PR TITLE
Allow custom UserDefaults object, bug fixed

### DIFF
--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -94,7 +94,7 @@ public class Zephyr: NSObject {
         shared.userDefaults = userDefaults
         
         if !keys.isEmpty {
-            sync(keys: keys)
+            sync(userDefaults: userDefaults, keys: keys)
             return
         }
         

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -22,38 +22,41 @@ public class Zephyr: NSObject {
     ///
     /// By default, this flag is set to **false**.
     public static var debugEnabled = false
-
+    
     /// If **true**, then NSUbiquitousKeyValueStore.synchronize() will be called immediately after any change is made.
     public static var syncUbiquitousKeyValueStoreOnChange = true
-
+    
     @available(*, deprecated: 2.2.1, unavailable, renamed: "syncUbiquitousKeyValueStoreOnChange")
     public static var syncUbiquitousStoreKeyValueStoreOnChange = true
-
+    
     /// The singleton for Zephyr.
     private static let shared = Zephyr()
-
+    
     /// A shared key that stores the last synchronization date between NSUserDefaults and NSUbiquitousKeyValueStore.
     private let ZephyrSyncKey = "ZephyrSyncKey"
-
+    
     /// An array of keys that should be actively monitored for changes.
     private var monitoredKeys = [String]()
-
+    
     /// An array of keys that are currently registered for observation.
     private var registeredObservationKeys = [String]()
-
+    
     /// A queue used to serialize synchronization on monitored keys.
     private let zephyrQueue = DispatchQueue(label: "com.zephyr.queue")
-
+    
     /// A session-persisted variable to directly access all of the NSUserDefaults elements.
     private var zephyrLocalStoreDictionary: [String: Any] {
-        return UserDefaults.standard.dictionaryRepresentation()
+        return userDefaults.dictionaryRepresentation()
     }
-
+    
     /// A session-persisted variable to directly access all of the NSUbiquitousKeyValueStore elements.
     private var zephyrRemoteStoreDictionary: [String: Any] {
         return NSUbiquitousKeyValueStore.default.dictionaryRepresentation
     }
-
+    
+    //The UserDefaults object to sync with NSUbiquitousKeyValueStore/iCloud
+    private var userDefaults: UserDefaults = UserDefaults.standard
+    
     /// Zephyr's initialization method.
     ///
     /// Do not call this method directly.
@@ -67,30 +70,34 @@ public class Zephyr: NSObject {
                                                object: nil)
         NSUbiquitousKeyValueStore.default.synchronize()
     }
-
+    
     /// Zephyr's de-initialization method.
     deinit {
         zephyrQueue.sync {
             for key in registeredObservationKeys {
-                UserDefaults.standard.removeObserver(self, forKeyPath: key)
+                userDefaults.removeObserver(self, forKeyPath: key)
             }
         }
     }
-
+    
     /// Zephyr's synchronization method.
     ///
     /// Zephyr will synchronize all NSUserDefaults with NSUbiquitousKeyValueStore.
     ///
     /// If one or more keys are passed, only those keys will be synchronized.
     ///
+    /// If a custom UserDefaults object is passed in, Zephyr will synchronize that rather than UserDefaults.standard
+    ///
     /// - Parameters:
     ///     - keys: If you pass a one or more keys, only those key will be synchronized. If no keys are passed, than all NSUserDefaults will be synchronized with NSUbiquitousKeyValueStore.
-    public static func sync(keys: String...) {
+    public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: String...) {
+        shared.userDefaults = userDefaults
+        
         if !keys.isEmpty {
             sync(keys: keys)
             return
         }
-
+        
         switch shared.dataStoreWithLatestData() {
         case .local:
             printGeneralSyncStatus(finished: false, destination: .remote)
@@ -106,14 +113,16 @@ public class Zephyr: NSObject {
             printGeneralSyncStatus(finished: true, destination: .local)
         }
     }
-
+    
     /// Overloaded version of Zephyr's synchronization method, **sync(keys:)**.
     ///
     /// This method will synchronize an array of keys between NSUserDefaults and NSUbiquitousKeyValueStore.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: An array of keys that should be synchronized between NSUserDefaults and NSUbiquitousKeyValueStore.
-    public static func sync(keys: [String]) {
+    public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: [String]) {
+        shared.userDefaults = userDefaults
+        
         switch shared.dataStoreWithLatestData() {
         case .local:
             printGeneralSyncStatus(finished: false, destination: .remote)
@@ -129,7 +138,7 @@ public class Zephyr: NSObject {
             printGeneralSyncStatus(finished: true, destination: .local)
         }
     }
-
+    
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
     /// be synchronized between both data stores whenever a change is detected
     ///
@@ -139,14 +148,14 @@ public class Zephyr: NSObject {
         for key in keys {
             if shared.monitoredKeys.contains(key) == false {
                 shared.monitoredKeys.append(key)
-
+                
                 shared.zephyrQueue.sync {
                     shared.registerObserver(key: key)
                 }
             }
         }
     }
-
+    
     /// Overloaded version of the **addKeysToBeMonitored(keys:)** method.
     ///
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
@@ -157,7 +166,7 @@ public class Zephyr: NSObject {
     public static func addKeysToBeMonitored(keys: String...) {
         addKeysToBeMonitored(keys: keys)
     }
-
+    
     /// Remove specific keys from being monitored in the background.
     ///
     /// - Parameters:
@@ -166,24 +175,24 @@ public class Zephyr: NSObject {
         for key in keys {
             if shared.monitoredKeys.contains(key) == true {
                 shared.monitoredKeys = shared.monitoredKeys.filter {$0 != key }
-
+                
                 shared.zephyrQueue.sync {
                     shared.unregisterObserver(key: key)
                 }
             }
         }
     }
-
+    
     /// Overloaded version of the **removeKeysFromBeingMonitored(keys:)** method.
     ///
     /// Remove specific keys from being monitored in the background.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: Pass one or more keys that you would like to stop monitoring.
     public static func removeKeysFromBeingMonitored(keys: String...) {
         removeKeysFromBeingMonitored(keys: keys)
     }
-
+    
 }
 
 // MARK: - Helpers
@@ -196,39 +205,39 @@ private extension Zephyr {
     ///
     /// - Returns: The persistent data store that has the newest data.
     func dataStoreWithLatestData() -> ZephyrDataStore {
-
+        
         if let remoteDate = zephyrRemoteStoreDictionary[ZephyrSyncKey] as? Date,
             let localDate = zephyrLocalStoreDictionary[ZephyrSyncKey] as? Date {
-
+            
             // If both localDate and remoteDate exist, compare the two, and then synchronize the data stores.
             return localDate.timeIntervalSince1970 > remoteDate.timeIntervalSince1970 ? .local : .remote
-
+            
         } else {
-
+            
             // If remoteDate doesn't exist, then assume local data is newer.
             guard let _ = zephyrRemoteStoreDictionary[ZephyrSyncKey] as? Date else {
                 return .local
             }
-
+            
             // If localDate doesn't exist, then assume that remote data is newer.
             guard let _ = zephyrLocalStoreDictionary[ZephyrSyncKey] as? Date else {
                 return .remote
             }
-
+            
             // If neither exist, synchronize local data store to iCloud.
             return .local
         }
-
+        
     }
-
+    
 }
 
 // MARK: - Synchronizers
 
 private extension Zephyr {
     /// Synchronizes specific keys to/from NSUbiquitousKeyValueStore and NSUserDefaults.
-    /// 
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///     - keys: Array of keys to synchronize.
     ///     - dataStore: Signifies if keys should be synchronized to/from iCloud.
     func syncSpecificKeys(keys: [String], dataStore: ZephyrDataStore) {
@@ -243,18 +252,18 @@ private extension Zephyr {
             }
         }
     }
-
+    
     /// Synchronizes all NSUserDefaults to NSUbiquitousKeyValueStore.
     ///
     /// If a key is passed, only that key will be synchronized.
-    /// 
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///     - key: If you pass a key, only that key will be updated in NSUbiquitousKeyValueStore.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncToCloud(key: String? = nil, value: Any? = nil) {
         let ubiquitousStore = NSUbiquitousKeyValueStore.default
         ubiquitousStore.set(Date(), forKey: ZephyrSyncKey)
-
+        
         // Sync all defaults to iCloud if key is nil, otherwise sync only the specific key/value pair.
         guard let key = key else {
             for (key, value) in zephyrLocalStoreDictionary {
@@ -266,12 +275,12 @@ private extension Zephyr {
                 }
                 registerObserver(key: key)
             }
-
+            
             return
         }
-
+        
         unregisterObserver(key: key)
-
+        
         if let value = value {
             ubiquitousStore.set(value, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .remote)
@@ -279,14 +288,14 @@ private extension Zephyr {
             NSUbiquitousKeyValueStore.default.removeObject(forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .remote)
         }
-
+        
         if Zephyr.syncUbiquitousKeyValueStoreOnChange {
             ubiquitousStore.synchronize()
         }
-
+        
         registerObserver(key: key)
     }
-
+    
     /// Synchronizes all NSUbiquitousKeyValueStore to NSUserDefaults.
     ///
     /// If a key is passed, only that key will be synchronized.
@@ -295,9 +304,9 @@ private extension Zephyr {
     ///     - key: If you pass a key, only that key will updated in NSUserDefaults.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncFromCloud(key: String? = nil, value: Any? = nil) {
-        let defaults = UserDefaults.standard
+        let defaults = userDefaults
         defaults.set(Date(), forKey: ZephyrSyncKey)
-
+        
         // Sync all defaults from iCloud if key is nil, otherwise sync only the specific key/value pair.
         guard let key = key else {
             for (key, value) in zephyrRemoteStoreDictionary {
@@ -306,12 +315,12 @@ private extension Zephyr {
                 Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
                 registerObserver(key: key)
             }
-
+            
             return
         }
-
+        
         unregisterObserver(key: key)
-
+        
         if let value = value {
             defaults.set(value, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
@@ -319,35 +328,35 @@ private extension Zephyr {
             defaults.set(nil, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: nil, destination: .local)
         }
-
+        
         registerObserver(key: key)
     }
-
+    
 }
 
 // MARK: - Observers
 
 extension Zephyr {
-
+    
     /// Adds key-value observation after synchronization of a specific key.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key that should be added and monitored.
     private func registerObserver(key: String) {
         if key == ZephyrSyncKey {
             return
         }
-
+        
         if !registeredObservationKeys.contains(key) {
-
-            UserDefaults.standard.addObserver(self, forKeyPath: key, options: .new, context: nil)
+            
+            userDefaults.addObserver(self, forKeyPath: key, options: .new, context: nil)
             registeredObservationKeys.append(key)
-
+            
         }
-
+        
         Zephyr.printObservationStatus(key: key, subscribed: true)
     }
-
+    
     /// Removes key-value observation before synchronization of a specific key.
     ///
     /// - Parameters:
@@ -356,29 +365,29 @@ extension Zephyr {
         if key == ZephyrSyncKey {
             return
         }
-
+        
         if let index = registeredObservationKeys.index(of: key) {
-
-            UserDefaults.standard.removeObserver(self, forKeyPath: key, context: nil)
+            
+            userDefaults.removeObserver(self, forKeyPath: key, context: nil)
             registeredObservationKeys.remove(at: index)
-
+            
         }
-
+        
         Zephyr.printObservationStatus(key: key, subscribed: false)
     }
-
+    
     public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let keyPath = keyPath, let object = object, monitoredKeys.contains(keyPath) else {
             return
         }
-
+        
         // Synchronize changes if key is monitored and if key is currently registered to respond to changes
         zephyrQueue.async {
             if self.registeredObservationKeys.contains(keyPath) {
                 if object is UserDefaults {
-                    UserDefaults.standard.set(Date(), forKey: self.ZephyrSyncKey)
+                    self.userDefaults.set(Date(), forKey: self.ZephyrSyncKey)
                 }
-
+                
                 self.syncSpecificKeys(keys: [keyPath], dataStore: .local)
             }
         }
@@ -388,12 +397,12 @@ extension Zephyr {
 // MARK: - Observers (Objective-C)
 
 @objc extension Zephyr {
-
+    
     /// Observation method for UIApplicationWillEnterForegroundNotification
     func willEnterForeground(notification: Notification) {
         NSUbiquitousKeyValueStore.default.synchronize()
     }
-
+    
     ///  Observation method for NSUbiquitousKeyValueStoreDidChangeExternallyNotification
     func keysDidChangeOnCloud(notification: Notification) {
         if notification.name == NSUbiquitousKeyValueStore.didChangeExternallyNotification {
@@ -404,13 +413,13 @@ extension Zephyr {
                 remoteStoredDate.timeIntervalSince1970 > localStoredDate.timeIntervalSince1970 else {
                     return
             }
-
+            
             for key in monitoredKeys where cloudKeys.contains(key) {
                 syncSpecificKeys(keys: [key], dataStore: .remote)
             }
         }
     }
-
+    
 }
 
 // MARK: - Loggers
@@ -422,19 +431,19 @@ private extension Zephyr {
     ///     - debugEnabled == true
     ///     - finished: The current status of syncing
     static func printGeneralSyncStatus(finished: Bool, destination dataStore: ZephyrDataStore) {
-
+        
         if debugEnabled == true {
             let destination = dataStore == .local ? "FROM iCloud" : "TO iCloud."
-
+            
             var message = "Started synchronization \(destination)"
             if finished == true {
                 message = "Finished synchronization \(destination)"
             }
-
+            
             printStatus(status: message)
         }
     }
-
+    
     /// Prints the key, value, and destination of the synchronized information if debugEnabled == true
     ///
     /// - Parameters:
@@ -444,36 +453,36 @@ private extension Zephyr {
     static func printKeySyncStatus(key: String, value: Any?, destination dataStore: ZephyrDataStore) {
         if debugEnabled == true {
             let destination = dataStore == .local ? "FROM iCloud" : "TO iCloud."
-
+            
             guard let value = value else {
                 let message = "Synchronized key '\(key)' with value 'nil' \(destination)"
                 printStatus(status: message)
                 return
             }
-
+            
             let message = "Synchronized key '\(key)' with value '\(value)' \(destination)"
             printStatus(status: message)
         }
     }
-
+    
     /// Prints the subscription state for a specific key if debugEnabled == true
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key being synchronized.
     ///     - subscribed: The subscription status of the key.
     static func printObservationStatus(key: String, subscribed: Bool) {
         if debugEnabled {
             let subscriptionState = subscribed == true ? "Subscribed" : "Unsubscribed"
             let preposition = subscribed == true ? "for" : "from"
-
+            
             let message = "\(subscriptionState) '\(key)' \(preposition) observation."
             printStatus(status: message)
         }
     }
-
+    
     /// Prints a status to the console if
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - debugEnabled == true
     ///     - status: The string that should be printed to the console.
     static func printStatus(status: String) {

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -22,41 +22,41 @@ public class Zephyr: NSObject {
     ///
     /// By default, this flag is set to **false**.
     public static var debugEnabled = false
-    
+
     /// If **true**, then NSUbiquitousKeyValueStore.synchronize() will be called immediately after any change is made.
     public static var syncUbiquitousKeyValueStoreOnChange = true
-    
+
     @available(*, deprecated: 2.2.1, unavailable, renamed: "syncUbiquitousKeyValueStoreOnChange")
     public static var syncUbiquitousStoreKeyValueStoreOnChange = true
-    
+
     /// The singleton for Zephyr.
     private static let shared = Zephyr()
-    
+
     /// A shared key that stores the last synchronization date between NSUserDefaults and NSUbiquitousKeyValueStore.
     private let ZephyrSyncKey = "ZephyrSyncKey"
-    
+
     /// An array of keys that should be actively monitored for changes.
     private var monitoredKeys = [String]()
-    
+
     /// An array of keys that are currently registered for observation.
     private var registeredObservationKeys = [String]()
-    
+
     /// A queue used to serialize synchronization on monitored keys.
     private let zephyrQueue = DispatchQueue(label: "com.zephyr.queue")
-    
+
     /// A session-persisted variable to directly access all of the NSUserDefaults elements.
     private var zephyrLocalStoreDictionary: [String: Any] {
         return userDefaults.dictionaryRepresentation()
     }
-    
+
     /// A session-persisted variable to directly access all of the NSUbiquitousKeyValueStore elements.
     private var zephyrRemoteStoreDictionary: [String: Any] {
         return NSUbiquitousKeyValueStore.default.dictionaryRepresentation
     }
-    
+
     //The UserDefaults object to sync with NSUbiquitousKeyValueStore/iCloud
     private var userDefaults: UserDefaults = UserDefaults.standard
-    
+
     /// Zephyr's initialization method.
     ///
     /// Do not call this method directly.
@@ -70,7 +70,7 @@ public class Zephyr: NSObject {
                                                object: nil)
         NSUbiquitousKeyValueStore.default.synchronize()
     }
-    
+
     /// Zephyr's de-initialization method.
     deinit {
         zephyrQueue.sync {
@@ -79,7 +79,7 @@ public class Zephyr: NSObject {
             }
         }
     }
-    
+
     /// Zephyr's synchronization method.
     ///
     /// Zephyr will synchronize all NSUserDefaults with NSUbiquitousKeyValueStore.
@@ -92,12 +92,12 @@ public class Zephyr: NSObject {
     ///     - keys: If you pass a one or more keys, only those key will be synchronized. If no keys are passed, than all NSUserDefaults will be synchronized with NSUbiquitousKeyValueStore.
     public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: String...) {
         shared.userDefaults = userDefaults
-        
+
         if !keys.isEmpty {
             sync(userDefaults: userDefaults, keys: keys)
             return
         }
-        
+
         switch shared.dataStoreWithLatestData() {
         case .local:
             printGeneralSyncStatus(finished: false, destination: .remote)
@@ -113,7 +113,7 @@ public class Zephyr: NSObject {
             printGeneralSyncStatus(finished: true, destination: .local)
         }
     }
-    
+
     /// Overloaded version of Zephyr's synchronization method, **sync(keys:)**.
     ///
     /// This method will synchronize an array of keys between NSUserDefaults and NSUbiquitousKeyValueStore.
@@ -122,7 +122,7 @@ public class Zephyr: NSObject {
     ///     - keys: An array of keys that should be synchronized between NSUserDefaults and NSUbiquitousKeyValueStore.
     public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: [String]) {
         shared.userDefaults = userDefaults
-        
+
         switch shared.dataStoreWithLatestData() {
         case .local:
             printGeneralSyncStatus(finished: false, destination: .remote)
@@ -138,7 +138,7 @@ public class Zephyr: NSObject {
             printGeneralSyncStatus(finished: true, destination: .local)
         }
     }
-    
+
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
     /// be synchronized between both data stores whenever a change is detected
     ///
@@ -148,14 +148,14 @@ public class Zephyr: NSObject {
         for key in keys {
             if shared.monitoredKeys.contains(key) == false {
                 shared.monitoredKeys.append(key)
-                
+
                 shared.zephyrQueue.sync {
                     shared.registerObserver(key: key)
                 }
             }
         }
     }
-    
+
     /// Overloaded version of the **addKeysToBeMonitored(keys:)** method.
     ///
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
@@ -166,7 +166,7 @@ public class Zephyr: NSObject {
     public static func addKeysToBeMonitored(keys: String...) {
         addKeysToBeMonitored(keys: keys)
     }
-    
+
     /// Remove specific keys from being monitored in the background.
     ///
     /// - Parameters:
@@ -175,14 +175,14 @@ public class Zephyr: NSObject {
         for key in keys {
             if shared.monitoredKeys.contains(key) == true {
                 shared.monitoredKeys = shared.monitoredKeys.filter {$0 != key }
-                
+
                 shared.zephyrQueue.sync {
                     shared.unregisterObserver(key: key)
                 }
             }
         }
     }
-    
+
     /// Overloaded version of the **removeKeysFromBeingMonitored(keys:)** method.
     ///
     /// Remove specific keys from being monitored in the background.
@@ -192,7 +192,7 @@ public class Zephyr: NSObject {
     public static func removeKeysFromBeingMonitored(keys: String...) {
         removeKeysFromBeingMonitored(keys: keys)
     }
-    
+
 }
 
 // MARK: - Helpers
@@ -205,31 +205,31 @@ private extension Zephyr {
     ///
     /// - Returns: The persistent data store that has the newest data.
     func dataStoreWithLatestData() -> ZephyrDataStore {
-        
+
         if let remoteDate = zephyrRemoteStoreDictionary[ZephyrSyncKey] as? Date,
             let localDate = zephyrLocalStoreDictionary[ZephyrSyncKey] as? Date {
-            
+
             // If both localDate and remoteDate exist, compare the two, and then synchronize the data stores.
             return localDate.timeIntervalSince1970 > remoteDate.timeIntervalSince1970 ? .local : .remote
-            
+
         } else {
-            
+
             // If remoteDate doesn't exist, then assume local data is newer.
             guard let _ = zephyrRemoteStoreDictionary[ZephyrSyncKey] as? Date else {
                 return .local
             }
-            
+
             // If localDate doesn't exist, then assume that remote data is newer.
             guard let _ = zephyrLocalStoreDictionary[ZephyrSyncKey] as? Date else {
                 return .remote
             }
-            
+
             // If neither exist, synchronize local data store to iCloud.
             return .local
         }
-        
+
     }
-    
+
 }
 
 // MARK: - Synchronizers
@@ -252,7 +252,7 @@ private extension Zephyr {
             }
         }
     }
-    
+
     /// Synchronizes all NSUserDefaults to NSUbiquitousKeyValueStore.
     ///
     /// If a key is passed, only that key will be synchronized.
@@ -263,7 +263,7 @@ private extension Zephyr {
     func syncToCloud(key: String? = nil, value: Any? = nil) {
         let ubiquitousStore = NSUbiquitousKeyValueStore.default
         ubiquitousStore.set(Date(), forKey: ZephyrSyncKey)
-        
+
         // Sync all defaults to iCloud if key is nil, otherwise sync only the specific key/value pair.
         guard let key = key else {
             for (key, value) in zephyrLocalStoreDictionary {
@@ -275,12 +275,12 @@ private extension Zephyr {
                 }
                 registerObserver(key: key)
             }
-            
+
             return
         }
-        
+
         unregisterObserver(key: key)
-        
+
         if let value = value {
             ubiquitousStore.set(value, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .remote)
@@ -288,14 +288,14 @@ private extension Zephyr {
             NSUbiquitousKeyValueStore.default.removeObject(forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .remote)
         }
-        
+
         if Zephyr.syncUbiquitousKeyValueStoreOnChange {
             ubiquitousStore.synchronize()
         }
-        
+
         registerObserver(key: key)
     }
-    
+
     /// Synchronizes all NSUbiquitousKeyValueStore to NSUserDefaults.
     ///
     /// If a key is passed, only that key will be synchronized.
@@ -306,7 +306,7 @@ private extension Zephyr {
     func syncFromCloud(key: String? = nil, value: Any? = nil) {
         let defaults = userDefaults
         defaults.set(Date(), forKey: ZephyrSyncKey)
-        
+
         // Sync all defaults from iCloud if key is nil, otherwise sync only the specific key/value pair.
         guard let key = key else {
             for (key, value) in zephyrRemoteStoreDictionary {
@@ -315,12 +315,12 @@ private extension Zephyr {
                 Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
                 registerObserver(key: key)
             }
-            
+
             return
         }
-        
+
         unregisterObserver(key: key)
-        
+
         if let value = value {
             defaults.set(value, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
@@ -328,16 +328,16 @@ private extension Zephyr {
             defaults.set(nil, forKey: key)
             Zephyr.printKeySyncStatus(key: key, value: nil, destination: .local)
         }
-        
+
         registerObserver(key: key)
     }
-    
+
 }
 
 // MARK: - Observers
 
 extension Zephyr {
-    
+
     /// Adds key-value observation after synchronization of a specific key.
     ///
     /// - Parameters:
@@ -346,17 +346,17 @@ extension Zephyr {
         if key == ZephyrSyncKey {
             return
         }
-        
+
         if !registeredObservationKeys.contains(key) {
-            
+
             userDefaults.addObserver(self, forKeyPath: key, options: .new, context: nil)
             registeredObservationKeys.append(key)
-            
+
         }
-        
+
         Zephyr.printObservationStatus(key: key, subscribed: true)
     }
-    
+
     /// Removes key-value observation before synchronization of a specific key.
     ///
     /// - Parameters:
@@ -365,29 +365,29 @@ extension Zephyr {
         if key == ZephyrSyncKey {
             return
         }
-        
+
         if let index = registeredObservationKeys.index(of: key) {
-            
+
             userDefaults.removeObserver(self, forKeyPath: key, context: nil)
             registeredObservationKeys.remove(at: index)
-            
+
         }
-        
+
         Zephyr.printObservationStatus(key: key, subscribed: false)
     }
-    
+
     public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let keyPath = keyPath, let object = object, monitoredKeys.contains(keyPath) else {
             return
         }
-        
+
         // Synchronize changes if key is monitored and if key is currently registered to respond to changes
         zephyrQueue.async {
             if self.registeredObservationKeys.contains(keyPath) {
                 if object is UserDefaults {
                     self.userDefaults.set(Date(), forKey: self.ZephyrSyncKey)
                 }
-                
+
                 self.syncSpecificKeys(keys: [keyPath], dataStore: .local)
             }
         }
@@ -397,12 +397,12 @@ extension Zephyr {
 // MARK: - Observers (Objective-C)
 
 @objc extension Zephyr {
-    
+
     /// Observation method for UIApplicationWillEnterForegroundNotification
     func willEnterForeground(notification: Notification) {
         NSUbiquitousKeyValueStore.default.synchronize()
     }
-    
+
     ///  Observation method for NSUbiquitousKeyValueStoreDidChangeExternallyNotification
     func keysDidChangeOnCloud(notification: Notification) {
         if notification.name == NSUbiquitousKeyValueStore.didChangeExternallyNotification {
@@ -413,13 +413,13 @@ extension Zephyr {
                 remoteStoredDate.timeIntervalSince1970 > localStoredDate.timeIntervalSince1970 else {
                     return
             }
-            
+
             for key in monitoredKeys where cloudKeys.contains(key) {
                 syncSpecificKeys(keys: [key], dataStore: .remote)
             }
         }
     }
-    
+
 }
 
 // MARK: - Loggers
@@ -431,19 +431,19 @@ private extension Zephyr {
     ///     - debugEnabled == true
     ///     - finished: The current status of syncing
     static func printGeneralSyncStatus(finished: Bool, destination dataStore: ZephyrDataStore) {
-        
+
         if debugEnabled == true {
             let destination = dataStore == .local ? "FROM iCloud" : "TO iCloud."
-            
+
             var message = "Started synchronization \(destination)"
             if finished == true {
                 message = "Finished synchronization \(destination)"
             }
-            
+
             printStatus(status: message)
         }
     }
-    
+
     /// Prints the key, value, and destination of the synchronized information if debugEnabled == true
     ///
     /// - Parameters:
@@ -453,18 +453,18 @@ private extension Zephyr {
     static func printKeySyncStatus(key: String, value: Any?, destination dataStore: ZephyrDataStore) {
         if debugEnabled == true {
             let destination = dataStore == .local ? "FROM iCloud" : "TO iCloud."
-            
+
             guard let value = value else {
                 let message = "Synchronized key '\(key)' with value 'nil' \(destination)"
                 printStatus(status: message)
                 return
             }
-            
+
             let message = "Synchronized key '\(key)' with value '\(value)' \(destination)"
             printStatus(status: message)
         }
     }
-    
+
     /// Prints the subscription state for a specific key if debugEnabled == true
     ///
     /// - Parameters:
@@ -474,12 +474,12 @@ private extension Zephyr {
         if debugEnabled {
             let subscriptionState = subscribed == true ? "Subscribed" : "Unsubscribed"
             let preposition = subscribed == true ? "for" : "from"
-            
+
             let message = "\(subscriptionState) '\(key)' \(preposition) observation."
             printStatus(status: message)
         }
     }
-    
+
     /// Prints a status to the console if
     ///
     /// - Parameters:
@@ -491,3 +491,4 @@ private extension Zephyr {
         }
     }
 }
+

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -161,7 +161,7 @@ public class Zephyr: NSObject {
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
     /// be synchronized between both data stores whenever a change is detected
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: Pass one or more keys that you would like to begin monitoring.
     public static func addKeysToBeMonitored(keys: String...) {
         addKeysToBeMonitored(keys: keys)
@@ -169,7 +169,7 @@ public class Zephyr: NSObject {
 
     /// Remove specific keys from being monitored in the background.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///    - keys: Pass one or more keys that you would like to stop monitoring.
     public static func removeKeysFromBeingMonitored(keys: [String]) {
         for key in keys {
@@ -236,7 +236,7 @@ private extension Zephyr {
 
 private extension Zephyr {
     /// Synchronizes specific keys to/from NSUbiquitousKeyValueStore and NSUserDefaults.
-    ///
+    /// 
     /// - Parameters: 
     ///     - keys: Array of keys to synchronize.
     ///     - dataStore: Signifies if keys should be synchronized to/from iCloud.
@@ -256,7 +256,7 @@ private extension Zephyr {
     /// Synchronizes all NSUserDefaults to NSUbiquitousKeyValueStore.
     ///
     /// If a key is passed, only that key will be synchronized.
-    ///
+    /// 
     /// - Parameters: 
     ///     - key: If you pass a key, only that key will be updated in NSUbiquitousKeyValueStore.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
@@ -300,7 +300,7 @@ private extension Zephyr {
     ///
     /// If a key is passed, only that key will be synchronized.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: If you pass a key, only that key will updated in NSUserDefaults.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncFromCloud(key: String? = nil, value: Any? = nil) {
@@ -359,7 +359,7 @@ extension Zephyr {
 
     /// Removes key-value observation before synchronization of a specific key.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key that should be removed from being monitored.
     private func unregisterObserver(key: String) {
         if key == ZephyrSyncKey {
@@ -427,7 +427,7 @@ extension Zephyr {
 private extension Zephyr {
     /// Prints Zephyr's current sync status if
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - debugEnabled == true
     ///     - finished: The current status of syncing
     static func printGeneralSyncStatus(finished: Bool, destination dataStore: ZephyrDataStore) {
@@ -446,7 +446,7 @@ private extension Zephyr {
 
     /// Prints the key, value, and destination of the synchronized information if debugEnabled == true
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key being synchronized.
     ///     - value: The value being synchronized.
     ///     - destination: The data store that is receiving the updated key-value pair.
@@ -491,4 +491,3 @@ private extension Zephyr {
         }
     }
 }
-

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -88,7 +88,7 @@ public class Zephyr: NSObject {
     ///
     /// If a custom UserDefaults object is passed in, Zephyr will synchronize that rather than UserDefaults.standard
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - keys: If you pass a one or more keys, only those key will be synchronized. If no keys are passed, than all NSUserDefaults will be synchronized with NSUbiquitousKeyValueStore.
     public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: String...) {
         shared.userDefaults = userDefaults
@@ -118,7 +118,7 @@ public class Zephyr: NSObject {
     ///
     /// This method will synchronize an array of keys between NSUserDefaults and NSUbiquitousKeyValueStore.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - keys: An array of keys that should be synchronized between NSUserDefaults and NSUbiquitousKeyValueStore.
     public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: [String]) {
         shared.userDefaults = userDefaults
@@ -161,7 +161,7 @@ public class Zephyr: NSObject {
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
     /// be synchronized between both data stores whenever a change is detected
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - keys: Pass one or more keys that you would like to begin monitoring.
     public static func addKeysToBeMonitored(keys: String...) {
         addKeysToBeMonitored(keys: keys)
@@ -169,7 +169,7 @@ public class Zephyr: NSObject {
 
     /// Remove specific keys from being monitored in the background.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///    - keys: Pass one or more keys that you would like to stop monitoring.
     public static func removeKeysFromBeingMonitored(keys: [String]) {
         for key in keys {
@@ -187,7 +187,7 @@ public class Zephyr: NSObject {
     ///
     /// Remove specific keys from being monitored in the background.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - keys: Pass one or more keys that you would like to stop monitoring.
     public static func removeKeysFromBeingMonitored(keys: String...) {
         removeKeysFromBeingMonitored(keys: keys)
@@ -237,7 +237,7 @@ private extension Zephyr {
 private extension Zephyr {
     /// Synchronizes specific keys to/from NSUbiquitousKeyValueStore and NSUserDefaults.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - keys: Array of keys to synchronize.
     ///     - dataStore: Signifies if keys should be synchronized to/from iCloud.
     func syncSpecificKeys(keys: [String], dataStore: ZephyrDataStore) {
@@ -257,7 +257,7 @@ private extension Zephyr {
     ///
     /// If a key is passed, only that key will be synchronized.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: If you pass a key, only that key will be updated in NSUbiquitousKeyValueStore.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncToCloud(key: String? = nil, value: Any? = nil) {
@@ -300,7 +300,7 @@ private extension Zephyr {
     ///
     /// If a key is passed, only that key will be synchronized.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: If you pass a key, only that key will updated in NSUserDefaults.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncFromCloud(key: String? = nil, value: Any? = nil) {
@@ -340,7 +340,7 @@ extension Zephyr {
 
     /// Adds key-value observation after synchronization of a specific key.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: The key that should be added and monitored.
     private func registerObserver(key: String) {
         if key == ZephyrSyncKey {
@@ -359,7 +359,7 @@ extension Zephyr {
 
     /// Removes key-value observation before synchronization of a specific key.
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: The key that should be removed from being monitored.
     private func unregisterObserver(key: String) {
         if key == ZephyrSyncKey {
@@ -427,7 +427,7 @@ extension Zephyr {
 private extension Zephyr {
     /// Prints Zephyr's current sync status if
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - debugEnabled == true
     ///     - finished: The current status of syncing
     static func printGeneralSyncStatus(finished: Bool, destination dataStore: ZephyrDataStore) {
@@ -446,7 +446,7 @@ private extension Zephyr {
 
     /// Prints the key, value, and destination of the synchronized information if debugEnabled == true
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: The key being synchronized.
     ///     - value: The value being synchronized.
     ///     - destination: The data store that is receiving the updated key-value pair.
@@ -467,7 +467,7 @@ private extension Zephyr {
 
     /// Prints the subscription state for a specific key if debugEnabled == true
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - key: The key being synchronized.
     ///     - subscribed: The subscription status of the key.
     static func printObservationStatus(key: String, subscribed: Bool) {
@@ -482,7 +482,7 @@ private extension Zephyr {
 
     /// Prints a status to the console if
     ///
-    /// - Parameters:
+    /// - Parameters: 
     ///     - debugEnabled == true
     ///     - status: The string that should be printed to the console.
     static func printStatus(status: String) {

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -86,15 +86,12 @@ public class Zephyr: NSObject {
     ///
     /// If one or more keys are passed, only those keys will be synchronized.
     ///
-    /// If a custom UserDefaults object is passed in, Zephyr will synchronize that rather than UserDefaults.standard
-    ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: If you pass a one or more keys, only those key will be synchronized. If no keys are passed, than all NSUserDefaults will be synchronized with NSUbiquitousKeyValueStore.
-    public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: String...) {
-        shared.userDefaults = userDefaults
+    public static func sync(keys: String...) {
 
         if !keys.isEmpty {
-            sync(userDefaults: userDefaults, keys: keys)
+            sync(keys: keys)
             return
         }
 
@@ -118,10 +115,9 @@ public class Zephyr: NSObject {
     ///
     /// This method will synchronize an array of keys between NSUserDefaults and NSUbiquitousKeyValueStore.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: An array of keys that should be synchronized between NSUserDefaults and NSUbiquitousKeyValueStore.
-    public static func sync(userDefaults: UserDefaults = UserDefaults.standard, keys: [String]) {
-        shared.userDefaults = userDefaults
+    public static func sync(keys: [String]) {
 
         switch shared.dataStoreWithLatestData() {
         case .local:
@@ -137,6 +133,32 @@ public class Zephyr: NSObject {
             }
             printGeneralSyncStatus(finished: true, destination: .local)
         }
+    }
+
+    /// Overloaded version of Zephyr's synchronization method, **sync(keys:)**.
+    ///
+    /// If a custom UserDefaults object is passed in, Zephyr will synchronize that rather than UserDefaults.standard
+    ///
+    /// - Parameters:
+    ///     - userDefaults: The UserDefaults object that should be synchronized with UbiquitousKeyValueStore.default
+    ///       default value is UserDefaults.standard
+    ///     - keys: If you pass a one or more keys, only those key will be synchronized. If no keys are passed, than all NSUserDefaults will be synchronized with NSUbiquitousKeyValueStore.
+    public static func sync(keys: String..., userDefaults: UserDefaults = UserDefaults.standard) {
+        shared.userDefaults = userDefaults
+        sync(keys: keys)
+    }
+
+    /// Overloaded version of Zephyr's synchronization method, **sync(keys:)**.
+    ///
+    /// If a custom UserDefaults object is passed in, Zephyr will synchronize that rather than UserDefaults.standard
+    ///
+    /// - Parameters:
+    ///     - userDefaults: The UserDefaults object that should be synchronized with UbiquitousKeyValueStore.default
+    ///       default value is UserDefaults.standard
+    ///     - keys: An array of keys that should be synchronized between NSUserDefaults and NSUbiquitousKeyValueStore.
+    public static func sync(keys: [String], userDefaults: UserDefaults = UserDefaults.standard) {
+        shared.userDefaults = userDefaults
+        sync(keys: keys)
     }
 
     /// Add specific keys to be monitored in the background. Monitored keys will automatically
@@ -187,7 +209,7 @@ public class Zephyr: NSObject {
     ///
     /// Remove specific keys from being monitored in the background.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - keys: Pass one or more keys that you would like to stop monitoring.
     public static func removeKeysFromBeingMonitored(keys: String...) {
         removeKeysFromBeingMonitored(keys: keys)
@@ -236,8 +258,8 @@ private extension Zephyr {
 
 private extension Zephyr {
     /// Synchronizes specific keys to/from NSUbiquitousKeyValueStore and NSUserDefaults.
-    /// 
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///     - keys: Array of keys to synchronize.
     ///     - dataStore: Signifies if keys should be synchronized to/from iCloud.
     func syncSpecificKeys(keys: [String], dataStore: ZephyrDataStore) {
@@ -256,8 +278,8 @@ private extension Zephyr {
     /// Synchronizes all NSUserDefaults to NSUbiquitousKeyValueStore.
     ///
     /// If a key is passed, only that key will be synchronized.
-    /// 
-    /// - Parameters: 
+    ///
+    /// - Parameters:
     ///     - key: If you pass a key, only that key will be updated in NSUbiquitousKeyValueStore.
     ///     - value: The value that will be synchronized. Must be passed with a key, otherwise, nothing will happen.
     func syncToCloud(key: String? = nil, value: Any? = nil) {
@@ -340,7 +362,7 @@ extension Zephyr {
 
     /// Adds key-value observation after synchronization of a specific key.
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key that should be added and monitored.
     private func registerObserver(key: String) {
         if key == ZephyrSyncKey {
@@ -467,7 +489,7 @@ private extension Zephyr {
 
     /// Prints the subscription state for a specific key if debugEnabled == true
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - key: The key being synchronized.
     ///     - subscribed: The subscription status of the key.
     static func printObservationStatus(key: String, subscribed: Bool) {
@@ -482,7 +504,7 @@ private extension Zephyr {
 
     /// Prints a status to the console if
     ///
-    /// - Parameters: 
+    /// - Parameters:
     ///     - debugEnabled == true
     ///     - status: The string that should be printed to the console.
     static func printStatus(status: String) {


### PR DESCRIPTION
Added an optional parameter to Zephyr.sync(), taking a custom UserDefaults object and using that in place of always using the container-wide UserDefaults.standard.

Fixed bug resulting in UserDefaults.standard being used despite passing in a custom UserDefaults object to the variable-arguments sync() function (when no keys were passed in)