### PR TITLE
Added NotificationCenter post when keys have finished synchronization

### DIFF
--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Enumerates the Local (`UserDefaults`) and Remote (`NSUNSUbiquitousKeyValueStore`) data stores
 private enum ZephyrDataStore {
@@ -25,6 +26,9 @@ public final class Zephyr: NSObject {
 
     /// If **true**, then `NSUbiquitousKeyValueStore.synchronize()` will be called immediately after any change is made.
     public static var syncUbiquitousKeyValueStoreOnChange = true
+
+    /// A string containing the notification name that will be psoted when Zephyr receives updated data from iCloud
+    public static let keysDidChangeOnCloudNotification = Notification.Name("ZephyrKeysDidChangeOnCloudNotification")
 
     /// The singleton for Zephyr.
     private static let shared = Zephyr()
@@ -435,6 +439,9 @@ extension Zephyr {
             for key in monitoredKeys where cloudKeys.contains(key) {
                 syncSpecificKeys(keys: [key], dataStore: .remote)
             }
+
+            // Notify any observers that we have finished synchronizing an update from iCloud
+            NotificationCenter.default.post(name: Zephyr.keysDidChangeOnCloudNotification, object: nil)
         }
     }
 


### PR DESCRIPTION
This adds support for applications being notified when Zephyr has finished synchronizing iCloud changes. It's done with two changes:

1. It adds a static `keysDidChangeOnCloudNotification` notification name that anyone can observe.

2. It posts that notification in the `keysDidChangeOnCloud()` method when synchronization has finished.

So, if an app wants to be informed when synchronization has completed, they would write code like this:

    NotificationCenter.default.addObserver(self, selector: #selector(cloudDataChanged), name: Zephyr.keysDidChangeOnCloudNotification, object: nil)

Unrelated but part of this PR: I've added an import for UIKit at the top – Xcode complains if I don't have this, because there's already an observer for `UIApplication.willEnterForegroundNotification` and `UIApplication` comes from UIKit.