### PR TITLE
Make this universally compile with current versions of Swift and Xcode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,8 @@
+// swift-tools-version:4.0
 import PackageDescription
 
 let package = Package(
-  name: "Zephyr"
+    name: "Zephyr",
+    products: [.library(name: "Zephyr", targets: ["Zephyr"])],
+    targets: [.target(name: "Zephyr", path: "Sources")]
 )

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -67,7 +67,7 @@ public final class Zephyr: NSObject {
                                                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
                                                object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
-                                               name: UIApplication.willEnterForegroundNotification,
+                                               name: .UIApplicationWillEnterForeground,
                                                object: nil)
         NSUbiquitousKeyValueStore.default.synchronize()
     }

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if os(iOS) || os(tvOS) || os(watchOS)
 import UIKit
+#endif
 
 /// Enumerates the Local (`UserDefaults`) and Remote (`NSUNSUbiquitousKeyValueStore`) data stores
 private enum ZephyrDataStore {
@@ -66,9 +68,11 @@ public final class Zephyr: NSObject {
         NotificationCenter.default.addObserver(self, selector: #selector(keysDidChangeOnCloud(notification:)),
                                                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
                                                object: nil)
+        #if os(iOS) || os(tvOS) || os(watchOS)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
                                                name: .UIApplicationWillEnterForeground,
                                                object: nil)
+        #endif
         NSUbiquitousKeyValueStore.default.synchronize()
     }
 


### PR DESCRIPTION
This fixes a couple of issues that prevent the package from compiling with current versions of Swift and Xcode:

 * commit 6357a65:
      - updates `Package.swift` format to 4.0 as required by Swift 5 (and recommended for Swift 4)
 * commit 9ba6be1:
      -  tracks the `.UIApplicationWillEnterForeground` notification name change (Swift 4.2 onwards)
 * commit eae57a6:
      -  protects UIKit specifics with `#if os()` so Zephyr now compiles for macOS as well