### PR TITLE
Synchronize access to key syncing from cloud change notification

### DIFF
--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -458,8 +458,10 @@ extension Zephyr {
                 return
             }
 
-            for key in monitoredKeys where cloudKeys.contains(key) {
-                syncSpecificKeys(keys: [key], dataStore: .remote)
+            zephyrQueue.sync {
+                for key in monitoredKeys where cloudKeys.contains(key) {
+                    syncSpecificKeys(keys: [key], dataStore: .remote)
+                }
             }
 
             Zephyr.postNotificationAfterSyncFromCloud()


### PR DESCRIPTION
Potential fix for #54. This is the only place that I found where sync wasn't called on zephyr queue.