### PR TITLE
Support watchOS 9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Zephyr",
-    platforms: [.iOS(.v11), .tvOS(.v11)],
+    platforms: [.iOS(.v11), .tvOS(.v11), .watchOS("9.0")],
     products: [.library(name: "Zephyr", targets: ["Zephyr"])],
     targets: [.target(name: "Zephyr", path: "Sources")],  
     swiftLanguageVersions: [.v5]

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -9,9 +9,7 @@
 import Foundation
 #if os(iOS) || os(tvOS)
 import UIKit
-#endif
-
-#if os(watchOS)
+#elseif os(watchOS)
 import WatchKit
 #endif
 

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -11,6 +11,10 @@ import Foundation
 import UIKit
 #endif
 
+#if os(watchOS)
+import WatchKit
+#endif
+
 /// Enumerates the Local (`UserDefaults`) and Remote (`NSUNSUbiquitousKeyValueStore`) data stores
 private enum ZephyrDataStore {
     case local  // UserDefaults
@@ -233,6 +237,14 @@ private extension Zephyr {
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
                                                name: UIApplication.willEnterForegroundNotification,
                                                object: nil)
+        #endif
+        
+        #if os(watchOS)
+        if #available(watchOS 9.0, *) {
+            NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
+                                                   name: WKExtension.applicationWillEnterForegroundNotification,
+                                                   object: nil)
+        }
         #endif
     }
 

--- a/Zephyr.podspec
+++ b/Zephyr.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   # Deployment
   s.ios.deployment_target      = '11.0'
   s.tvos.deployment_target     = '11.0'
+  s.watchos.deployment_target  = '9.0'
 
   # Sources
   s.source       = { :git => "https://github.com/ArtSabintsev/Zephyr.git", :tag => s.version.to_s }


### PR DESCRIPTION
[NSUbiquitousKeyValueStore is now also supported in watchOS 9](https://developer.apple.com/documentation/foundation/nsubiquitouskeyvaluestore). Therefore we can add watchOS 9 as a target.

Closes #59 