### PR TITLE
Update Zephyr.swift

### DIFF
--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -551,6 +551,6 @@ private extension Zephyr {
 
     // Notify any observers that we have finished synchronizing an update from iCloud.
     static func postNotificationAfterSyncFromCloud() {
-        NotificationCenter.default.post(name: Zephyr.keysDidChangeOnCloudNotification, object: nil)
+        NotificationCenter.default.post(name: keysDidChangeOnCloudNotification, object: nil)
     }
 }


### PR DESCRIPTION
Deleting ‘Zephyr.’ Proposal to use:
```
static func postNotificationAfterSyncFromCloud() {
        let objToBeSent = "Test Message from Notification"
        NotificationCenter.default.post(name: keysDidChangeOnCloudNotification, object: objToBeSent)
    }
```

And further enhance the object to be sent with only the updated userdefault keys.

Then receiving the notification post using an observer:

```
NotificationCenter.default.addObserver(self, selector: #selector(yourmethod), name: Zephyr.keysDidChangeOnCloudNotification, object: objectname)
```