### PR TITLE
Fix race-condition between when keys are updated and when notification fires

### DIFF
--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -368,16 +368,12 @@ private extension Zephyr {
         }
 
         unregisterObserver(key: key)
-
-        if let value = value {
-            DispatchQueue.main.async { defaults.set(value, forKey: key) }
-            Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
-        } else {
-            DispatchQueue.main.async { defaults.set(nil, forKey: key) }
-            Zephyr.printKeySyncStatus(key: key, value: nil, destination: .local)
-        }
-
-        Zephyr.postNotificationAfterSyncFromCloud()
+		
+		DispatchQueue.main.async {
+			defaults.set(value, forKey: key)
+			Zephyr.printKeySyncStatus(key: key, value: value, destination: .local)
+			Zephyr.postNotificationAfterSyncFromCloud()
+		}
 
         registerObserver(key: key)
     }
@@ -472,9 +468,9 @@ extension Zephyr {
                 for key in monitoredKeys where cloudKeys.contains(key) {
                     syncSpecificKeys(keys: [key], dataStore: .remote)
                 }
+				
+				Zephyr.postNotificationAfterSyncFromCloud()
             }
-
-            Zephyr.postNotificationAfterSyncFromCloud()
         }
     }
 


### PR DESCRIPTION
Move syncFromCloud notification to same thread as where UserDefaults keys change. This ensures that the keysDidChange notification waits to fire until after the keys do change.

This is particularly helpful for ensuring that data is synced down and when launching an app fresh after installing it.