### PR TITLE
Added support for configuring the UserDefaults store before syncing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Zephyr",
-    platforms: [.iOS(.v11), .tvOS(.v11), .watchOS("9.0")],
+    platforms: [.iOS(.v11), .macOS(.v11), .tvOS(.v11), .watchOS("9.0")],
     products: [.library(name: "Zephyr", targets: ["Zephyr"])],
     targets: [.target(name: "Zephyr", path: "Sources")],  
     swiftLanguageVersions: [.v5]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Effortlessly sync UserDefaults over iCloud
 
-![Swift Support](https://img.shields.io/badge/Swift-5.3-orange.svg) [![Platform](https://img.shields.io/badge/Platforms-iOS%20%7c%20tvOS-lightgray.svg?style=flat)](http://cocoadocs.org/docsets/Zephyr) [![CocoaPods](https://img.shields.io/cocoapods/v/Zephyr.svg)]() [![SwiftPM Compatible](https://img.shields.io/badge/SwiftPM-Compatible-brightgreen.svg)](https://swift.org/package-manager/)
+![Swift Support](https://img.shields.io/badge/Swift-5.3-orange.svg) [![Platform](https://img.shields.io/badge/Platforms-iOS%20%7c%20macOS%20%7c%20tvOS%20%7c%20watchOS-lightgray.svg?style=flat)](http://cocoadocs.org/docsets/Zephyr) [![CocoaPods](https://img.shields.io/cocoapods/v/Zephyr.svg)]() [![SwiftPM Compatible](https://img.shields.io/badge/SwiftPM-Compatible-brightgreen.svg)](https://swift.org/package-manager/)
 
 ---
 ### About

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ In Xcode, open your app's project/workspace file:
 
 Before performing each sync, Zephyr automatically checks to see if the data in UserDefaults or NSUbiquitousKeyValueStore is newer. To make sure there's no overwriting going on in a fresh installation of your app on a new device that's connected to the same iCloud account, make sure that your UserDefaults are registered ***BEFORE*** calling any of the Zephyr methods. One way to easily achieve this is by using the [UserDefaults Register API](https://developer.apple.com/documentation/foundation/userdefaults/1417065-register).
 
+**Configure UserDefaults store (Dictionary Option)**
+
+```Swift
+Zephyr.configureStores(with: ["MyFirstKey": UserDefaults.standard, "MySecondKey": UserDefaults.shared)
+```
+
+**Configure UserDefaults store (Variadic Option)**
+
+```Swift
+Zephyr.configureStore(for: "MyFirstKey", "MySecondKey", ..., with: UserDefaults.standard)
+```
+
+**Configure UserDefaults store (Array Option)**
+
+```Swift
+Zephyr.configureStore(for: ["MyFirstKey", "MySecondKey", with: UserDefaults.standard)
+```
+
 **Sync all UserDefaults**
 ```Swift
 Zephyr.sync()


### PR DESCRIPTION
When using a custom UserDefaults store, attempting to add the keys to be monitored before syncing changes causes Zephyr to crash.

This adds the ability to set a custom UserDefaults store for each key and allow the configuration methods to be called before adding keys to be monitored and syncing changes. If it is not called, UserDefaults.standard is used instead for all keys or, for keys that have not been specified.