### PR TITLE
Add ability to set user defaults suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ Zephyr.debugEnabled = true // Must be called before sync(_:)
 Zephyr.sync()
 ```
 
+**Use a specific `UserDefaults` suite**
+```swift
+if let suite = UserDefaults(suiteName: "group.com.example.app-name") {
+  Zephyr.setUserDefaultsSuite(to: suite)
+}
+```
+
 ### Sample App
 
 Please ignore the Sample App as I did not add any demo code in the Sample App. It's only in this repo to add support for Carthage.

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -278,6 +278,15 @@ private extension Zephyr {
 
     }
 
+  /// Set Zephyr to use a different UserDefaults suite than `.standard`.
+  ///
+  /// - Parameters:
+  ///     - to: A `UserDefaults` suite.
+  public static func setUserDefaultsSuite(to suite: UserDefaults) {
+      shared.userDefaults = suite
+      printStatus(status: "Updated UserDefaults suite.")
+  }
+
 }
 
 // MARK: - Synchronizers


### PR DESCRIPTION
Hi,

Here's a small PR to add a function for setting which UserDefaults suite to use. I'm using it in my own app to make use of Zephyr while using App Groups.

Example usage:

```swift
if let suite = UserDefaults(suiteName: "group.com.example.app-name") {
    Zephyr.setUserDefaultsSuite(to: suite)
}
```

I'm not sure if you accept external PRs – if this isn't something you're looking for then no worries. I'm also happy to update this PR to document it in the readme, but I figured I'd wait to see what you think before doing that.