### PR TITLE
Add visionOS support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,9 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 import PackageDescription
 
 let package = Package(
     name: "Zephyr",
-    platforms: [.iOS(.v11), .tvOS(.v11), .watchOS("9.0")],
+    platforms: [.iOS(.v12), .tvOS(.v12), .watchOS(.v9), .visionOS(.v1)],
     products: [.library(name: "Zephyr", targets: ["Zephyr"])],
     targets: [.target(name: "Zephyr", path: "Sources")],  
     swiftLanguageVersions: [.v5]

--- a/Sources/Zephyr.swift
+++ b/Sources/Zephyr.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 #elseif os(watchOS)
 import WatchKit
@@ -225,8 +225,8 @@ private extension Zephyr {
                                                name: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
                                                object: nil)
 
-        #if os(iOS) || os(tvOS)
-        if #available(iOS 13.0, tvOS 13.0, *) {
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        if #available(iOS 13.0, tvOS 13.0, visionOS 1.0, *) {
             NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground(notification:)),
                                                    name: UIScene.willEnterForegroundNotification,
                                                    object: nil)

--- a/Zephyr.podspec
+++ b/Zephyr.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target      = '11.0'
   s.tvos.deployment_target     = '11.0'
   s.watchos.deployment_target  = '9.0'
+  s.visionos.deployment_target  = '1.0'
 
   # Sources
   s.source       = { :git => "https://github.com/ArtSabintsev/Zephyr.git", :tag => s.version.to_s }


### PR DESCRIPTION
Hi, me again. I added visionOS as a compatible platform. As always if not suitable feel free to close.

I'm not 100% sure I've done it correctly as I've never worked with Cocoapods or SPM files before. I've added some comments to the diff to explain where I'm unsure.

If you do release this, I _think_ it drops iOS 11 and tvOS 11 support, so I guess it should be a major version change under semver.